### PR TITLE
Update win32.py Allow for successive calls to notify on windows

### DIFF
--- a/ntfy/backends/win32.py
+++ b/ntfy/backends/win32.py
@@ -47,6 +47,9 @@ def notify(title, message, icon=icon.ico, **kwargs):
                                        win32con.WM_USER + 20, hicon,
                                        "Balloon tooltip", title, 200, msg))
             win32gui.DestroyWindow(self.hwnd)
+            
+            #allows for successive calls to notify method
+            win32gui.UnregisterClass(classAtom,hinst)
 
         def OnDestroy(self, hwnd, msg, wparam, lparam):
             win32api.PostQuitMessage(0)  # Terminate the app.


### PR DESCRIPTION
Successive calls to notify method raised an error on win 10.
_**pywintypes.error: (1410, 'RegisterClass', 'Class already exists.')**_.
Un-Registering the class after the notification is displayed and
destroyed eliminates this error.
